### PR TITLE
Fix documentation links and update bSDD resource references

### DIFF
--- a/Documentation/CONTRIBUTING.md
+++ b/Documentation/CONTRIBUTING.md
@@ -7,14 +7,14 @@ This repository at GitHub is, where the creators and implementers of Open Standa
 Here are some important resources:
 
   * [Information about buildingSMART](https://www.buildingsmart.org/) tells you who we are,
-  * [This website](http://www.buildingsmart-tech.org/) is the publishing platform for our latest standards
+  * [buildingSMART Technical](https://technical.buildingsmart.org/standards/) is the publishing platform for our latest standards
   * Our day to day exchange and discussions are on [our Discourse](https://forums.buildingsmart.org)
   * Bugs? Yes they exist, we would like to know them, so [Github](https://github.com/buildingSMART/bSDD/issues) is where to report them
-  * Features? Again Yes, we need you ideas and comments. Feel free to share them with us [here]((https://github.com/buildingSMART/bSDD/issues))
+  * Features? Again Yes, we need you ideas and comments. Feel free to share them with us [here](https://github.com/buildingSMART/bSDD/issues)
   
 ## Submitting changes
 
-Please send a [GitHub Pull Request](https://github.com/buildingSMART/bSDD/pull/new/master) with a clear list of what you've done (read more about [pull requests](http://help.github.com/pull-requests/)). When you send a pull request, we will love you forever if you include examples. We can always use more test coverage. Please follow our coding conventions (below) and make sure all of your commits are atomic (one feature per commit).
+Please send a [GitHub Pull Request](https://github.com/buildingSMART/bSDD/pull/new/master) with a clear list of what you've done (read more about [pull requests](https://docs.github.com/en/pull-requests/reference/pull-requests)). When you send a pull request, we will love you forever if you include examples. We can always use more test coverage. Please follow our coding conventions (below) and make sure all of your commits are atomic (one feature per commit).
 
 Always write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should look like this:
 

--- a/Documentation/RDF.md
+++ b/Documentation/RDF.md
@@ -12,4 +12,4 @@ You can request output in RDF-xml format by adding an HTTP header with key "Acce
 
 You can request output in turtle format by adding an HTTP header with key "Accept" and value "text/turtle" of "application/x-turtle".
 
-<img src="https://github.com/buildingSMART/bSDD/blob/documentation/Documentation/graphics/HowToGetOutputInTurtleFormat.PNG" alt="How to get output in turtle format"/>
+<img src="graphics/HowToGetOutputInTurtleFormat.PNG" alt="How to get output in turtle format"/>

--- a/Documentation/bSDD API.md
+++ b/Documentation/bSDD API.md
@@ -44,7 +44,7 @@ The URL to send GraphQL requests to is:
 - test version: https://test.bsdd.buildingsmart.org/graphqls (secured)
 Note: those URLs are not hyperlinks and do not work in a browser. You need to send a POST request with the query data (the GET request does not work).
 
-Here you can find an example code for accessing a secured bSDD API: [bSDD GraphQL examples](<bSDD and GraphQL.md>). Contact us if you need assistance implementing this.
+Here you can find an example code for accessing a secured bSDD API: [bSDD GraphQL examples](bSDD%20and%20GraphQL.md). Contact us if you need assistance implementing this.
  
 ## For client developers
 
@@ -72,7 +72,7 @@ At this moment, you need to authenticate only a few methods. This might change.
 
 If you’re developing a Javascript, Java, Angular, React, Python, or .NET application, connecting with the buildingSMART Data Dictionary API is easiest if you use the Microsoft Authentication Library (MSAL).
 See [Active directory B2C code samples](https://docs.microsoft.com/en-us/azure/active-directory-b2c/code-samples) for ready-to-use examples on how to use the MSAL. You can find the bSDD API-specific settings in one of the next sections of this document. Make sure you have the settings in an easy-to-update settings file. 
-You can find the code for a small .NET console application that accesses the bSDD API (authenticated) in this repository: [.NET console example](<../Source code examples/CSharp-Client-Console-Demo/>).
+You can find the code for a small .NET console application that accesses the bSDD API (authenticated) in this repository: [.NET console example](../Source%20code%20examples/CSharp-Client-Console-Demo/).
 
 React:  https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-v2-react
         https://github.com/Azure-Samples/ms-identity-javascript-react-tutorial/blob/main/1-Authentication/2-sign-in-b2c/README.md

--- a/Documentation/bSDD API.md
+++ b/Documentation/bSDD API.md
@@ -44,7 +44,7 @@ The URL to send GraphQL requests to is:
 - test version: https://test.bsdd.buildingsmart.org/graphqls (secured)
 Note: those URLs are not hyperlinks and do not work in a browser. You need to send a POST request with the query data (the GET request does not work).
 
-Here you can find an example code for accessing a secured bSDD API: [bSDD GraphQL examples](bSDD%20and%20GraphQL.md). Contact us if you need assistance implementing this.
+Here you can find an example code for accessing a secured bSDD API: [bSDD GraphQL examples](<bSDD and GraphQL.md>). Contact us if you need assistance implementing this.
  
 ## For client developers
 
@@ -72,7 +72,7 @@ At this moment, you need to authenticate only a few methods. This might change.
 
 If you’re developing a Javascript, Java, Angular, React, Python, or .NET application, connecting with the buildingSMART Data Dictionary API is easiest if you use the Microsoft Authentication Library (MSAL).
 See [Active directory B2C code samples](https://docs.microsoft.com/en-us/azure/active-directory-b2c/code-samples) for ready-to-use examples on how to use the MSAL. You can find the bSDD API-specific settings in one of the next sections of this document. Make sure you have the settings in an easy-to-update settings file. 
-You can find the code for a small .NET console application that accesses the bSDD API (authenticated) in this repository: [.NET console example](../Source%20code%20examples/CSharp-Client-Console-Demo/).
+You can find the code for a small .NET console application that accesses the bSDD API (authenticated) in this repository: [.NET console example](<../Source code examples/CSharp-Client-Console-Demo/>).
 
 React:  https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-v2-react
         https://github.com/Azure-Samples/ms-identity-javascript-react-tutorial/blob/main/1-Authentication/2-sign-in-b2c/README.md

--- a/Documentation/bSDD API.md
+++ b/Documentation/bSDD API.md
@@ -16,7 +16,7 @@ A typical use case is demonstrated in SketchUp. A video of the SketchUp use-case
 ## API contracts and testing the API
 You can get the API contract information at [bSDD API contract, official release](https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1). This information is available without the need for you to log in. You can also test the API methods. Secured methods are marked with a lock. To access secured methods, you need to log in via the UI by using the Authorize button:
 
-<img src="https://raw.githubusercontent.com/buildingSMART/bSDD/master/Documentation/graphics/swagger-authorize2.png" alt="Swagger authorization" style="width: 550px" />
+<img src="graphics/swagger-authorize2.png" alt="Swagger authorization" style="width: 550px" />
 
 Fill in the following client_id: b222e220-1f71-4962-9184-05e0481a390d
 
@@ -44,7 +44,7 @@ The URL to send GraphQL requests to is:
 - test version: https://test.bsdd.buildingsmart.org/graphqls (secured)
 Note: those URLs are not hyperlinks and do not work in a browser. You need to send a POST request with the query data (the GET request does not work).
 
-Here you can find an example code for accessing a secured bSDD API: [bSDD GraphQL examples](https://github.com/buildingSMART/bSDD/blob/master/Documentation/bSDD%20and%20GraphQL.md). Contact us if you need assistance implementing this.
+Here you can find an example code for accessing a secured bSDD API: [bSDD GraphQL examples](bSDD%20and%20GraphQL.md). Contact us if you need assistance implementing this.
  
 ## For client developers
 
@@ -72,7 +72,7 @@ At this moment, you need to authenticate only a few methods. This might change.
 
 If you’re developing a Javascript, Java, Angular, React, Python, or .NET application, connecting with the buildingSMART Data Dictionary API is easiest if you use the Microsoft Authentication Library (MSAL).
 See [Active directory B2C code samples](https://docs.microsoft.com/en-us/azure/active-directory-b2c/code-samples) for ready-to-use examples on how to use the MSAL. You can find the bSDD API-specific settings in one of the next sections of this document. Make sure you have the settings in an easy-to-update settings file. 
-You can find the code for a small .NET console application that accesses the bSDD API (authenticated) in this repository: [.NET console example](https://github.com/buildingSMART/bSDD/tree/master/Source%20code%20examples/CSharp-Client-Console-Demo).
+You can find the code for a small .NET console application that accesses the bSDD API (authenticated) in this repository: [.NET console example](../Source%20code%20examples/CSharp-Client-Console-Demo/).
 
 React:  https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-v2-react
         https://github.com/Azure-Samples/ms-identity-javascript-react-tutorial/blob/main/1-Authentication/2-sign-in-b2c/README.md
@@ -84,7 +84,7 @@ If you're developing using other languages, you can still connect to the bSDD AP
 
 To access a secured API, a user must first register themself. When you’re using MSAL, there’s nothing special you need to do for this. The user will be prompted to log in via a browser window. If the user does not have a buildingSMART API account, he can sign up:
 
-<img src="https://raw.githubusercontent.com/buildingSMART/bSDD/master/Documentation/graphics/bs-signupsignin.png" alt="bSDD sign up / sign in" style="width: 350px" />
+<img src="graphics/bs-signupsignin.png" alt="bSDD sign up / sign in" style="width: 350px" />
 
 The user will be registered in the buildingSMART Azure B2C Active Directory.
 Currently there’s no further authorization required to be able to use the API.
@@ -119,4 +119,3 @@ Language-independent description of the authorization flow: [Authorization code 
 High-level descriptions of the various authentication flows: [AD B2C application types](https://docs.microsoft.com/en-us/azure/active-directory-b2c/application-types)
 
 Oauth2 and OpenId protocol descriptions: [AD B2C protocols overview](https://docs.microsoft.com/en-us/azure/active-directory-b2c/protocols-overview)
-

--- a/Documentation/bSDD JSON import model.md
+++ b/Documentation/bSDD JSON import model.md
@@ -18,10 +18,10 @@
 
 The bSDD is a service to facilitate the distribution of data dictionaries (read below about what those are) published by independent organisations. The diagram below shows the simplified data model behind the bSDD:
 
-<img src="https://raw.githubusercontent.com/buildingSMART/bSDD/master/Documentation/graphics/bSDD_data_model.png" alt="bSDD entity diagram" style="width: 650px"/>
+<img src="graphics/bSDD_data_model.png" alt="bSDD entity diagram" style="width: 650px"/>
 
-See our example demonstrating the usage of the above concepts: [bSDD data example](https://raw.githubusercontent.com/buildingSMART/bSDD/master/Documentation/graphics/bSDD_data_example.png):
-<img src="https://raw.githubusercontent.com/buildingSMART/bSDD/master/Documentation/graphics/bSDD_data_example.png" alt="bSDD entity diagram" style="width: 700px"/>
+See our example demonstrating the usage of the above concepts: [bSDD data example](graphics/bSDD_data_example.png):
+<img src="graphics/bSDD_data_example.png" alt="bSDD entity diagram" style="width: 700px"/>
 
 We also have a demonstration dictionary: ["Fruit and vegetables"](https://search.bsdd.buildingsmart.org/uri/bs-agri/fruitvegs/1.1).
 
@@ -29,7 +29,7 @@ We also have a demonstration dictionary: ["Fruit and vegetables"](https://search
 
 <h2 id="json-format">JSON format</h2>
 
-You can deliver data for the buildingSMART Data Dictionary in the JSON file following our standard, which we explain in this document. You can also find the JSON and Excel templates in [/Model/Import Model](https://github.com/buildingSMART/bSDD/tree/master/Model/Import%20Model).
+You can deliver data for the buildingSMART Data Dictionary in the JSON file following our standard, which we explain in this document. You can also find the JSON and Excel templates in [/Model/Import Model](../Model/Import%20Model/).
 
 Click on the link to get the list of allowed codes for [countries](https://api.bsdd.buildingsmart.org/api/Country/v1), [languages](https://api.bsdd.buildingsmart.org/api/Language/v1), [units](https://api.bsdd.buildingsmart.org/api/Unit/v1), [reference documents](https://api.bsdd.buildingsmart.org/api/ReferenceDocument/v1) and [ifc class](https://api.bsdd.buildingsmart.org/api/Dictionary/v2/Classes?uri=https%3A%2F%2Fidentifier.buildingsmart.org%2Furi%2Fbuildingsmart%2Fifc%2F4.3).
 If you think there are reference documents missing, please let us know by [posting an issue](https://github.com/buildingSMART/bSDD/issues). All values in JSON must be strings captured in double quotes, including for numeric Example and AllowedValue fields.
@@ -62,7 +62,7 @@ NB Default values will only be applied if a field is not specified. If you speci
 | <span id="QualityAssuranceProcedure">QualityAssuranceProcedure</span>      | Text      | | | Name or short description of the quality assurance procedure used for the dictionary, Example: "ETIM international", "AFNOR NF XP P07-150 (PPBIM)", "bSI process", "UN GHS 2015", "UN CPC 1.1", "Private", "Unknown" |
 | <span id="QualityAssuranceProcedureUrl">QualityAssuranceProcedureUrl</span>   | Text      | | | Url to a web page with more detailed info on the quality assurance procedure, Example: "https://www.buildingsmart.org/about/bsi-process"  |
 | <span id="ReleaseDate">ReleaseDate</span>                    | DateTime  | | | Date of release of the version, See [Date Time format](#datetime-format).  |
-| <span id="Status">Status</span>                         | Text      | | | Possible version statuses: `Preview`, `Active`, `Inactive`. When uploading a new version, it should always be in `Preview`. You can then activate or deactivate content via [the API](https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1) or [Management Portal](https://manage.bsdd.buildingsmart.org/). Read more: [the lifecycle of the bSDD content](https://raw.githubusercontent.com/buildingSMART/bSDD/master/Documentation/bSDD%20import%20tutorial.md#the-lifecycle-of-the-bsdd-dictionary-version)  |
+| <span id="Status">Status</span>                         | Text      | | | Possible version statuses: `Preview`, `Active`, `Inactive`. When uploading a new version, it should always be in `Preview`. You can then activate or deactivate content via [the API](https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1) or [Management Portal](https://manage.bsdd.buildingsmart.org/). Read more: [the lifecycle of the bSDD content](bSDD%20import%20tutorial.md#the-lifecycle-of-a-dictionary)  |
 | <span id="Classes">Classes</span>          | List of Class    | ✅    | | List of objects of type `Class`. See section [Class](#class)  |
 | <span id="Properties">Properties</span>       | List of Property | ✅    | | List of objects of type `Property`. See section [Property](#property) |
 
@@ -308,7 +308,7 @@ In bSDD, all resources get a unique identifier - URI. The URI, among other infor
 If you want to reference specific resources but are not sure of the version or want to always point to the most recent version, we implemented the "latest" feature. Now, it is possible to use "latest" instead of a version number, and bSDD will resolve the link to the latest active or preview version containing that resource: 
 .../uri/bs-agri/fruitvegs/**latest**/class/fruit. 
 
-<img src="https://raw.githubusercontent.com/buildingSMART/bSDD/master/Documentation/graphics/latest_example.jpg" alt="bSDD latest" style="width: 750px"/>
+<img src="graphics/latest_example.jpg" alt="bSDD latest" style="width: 750px"/>
 
 Try it out:
 https://search.bsdd.buildingsmart.org/uri/bs-agri/fruitvegs/latest/class/fruit

--- a/Documentation/bSDD JSON import model.md
+++ b/Documentation/bSDD JSON import model.md
@@ -29,7 +29,7 @@ We also have a demonstration dictionary: ["Fruit and vegetables"](https://search
 
 <h2 id="json-format">JSON format</h2>
 
-You can deliver data for the buildingSMART Data Dictionary in the JSON file following our standard, which we explain in this document. You can also find the JSON and Excel templates in [/Model/Import Model](<../Model/Import Model/>).
+You can deliver data for the buildingSMART Data Dictionary in the JSON file following our standard, which we explain in this document. You can also find the JSON and Excel templates in [/Model/Import Model](../Model/Import%20Model/).
 
 Click on the link to get the list of allowed codes for [countries](https://api.bsdd.buildingsmart.org/api/Country/v1), [languages](https://api.bsdd.buildingsmart.org/api/Language/v1), [units](https://api.bsdd.buildingsmart.org/api/Unit/v1), [reference documents](https://api.bsdd.buildingsmart.org/api/ReferenceDocument/v1) and [ifc class](https://api.bsdd.buildingsmart.org/api/Dictionary/v2/Classes?uri=https%3A%2F%2Fidentifier.buildingsmart.org%2Furi%2Fbuildingsmart%2Fifc%2F4.3).
 If you think there are reference documents missing, please let us know by [posting an issue](https://github.com/buildingSMART/bSDD/issues). All values in JSON must be strings captured in double quotes, including for numeric Example and AllowedValue fields.
@@ -62,7 +62,7 @@ NB Default values will only be applied if a field is not specified. If you speci
 | <span id="QualityAssuranceProcedure">QualityAssuranceProcedure</span>      | Text      | | | Name or short description of the quality assurance procedure used for the dictionary, Example: "ETIM international", "AFNOR NF XP P07-150 (PPBIM)", "bSI process", "UN GHS 2015", "UN CPC 1.1", "Private", "Unknown" |
 | <span id="QualityAssuranceProcedureUrl">QualityAssuranceProcedureUrl</span>   | Text      | | | Url to a web page with more detailed info on the quality assurance procedure, Example: "https://www.buildingsmart.org/about/bsi-process"  |
 | <span id="ReleaseDate">ReleaseDate</span>                    | DateTime  | | | Date of release of the version, See [Date Time format](#datetime-format).  |
-| <span id="Status">Status</span>                         | Text      | | | Possible version statuses: `Preview`, `Active`, `Inactive`. When uploading a new version, it should always be in `Preview`. You can then activate or deactivate content via [the API](https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1) or [Management Portal](https://manage.bsdd.buildingsmart.org/). Read more: [the lifecycle of the bSDD content](<bSDD import tutorial.md#the-lifecycle-of-a-dictionary>)  |
+| <span id="Status">Status</span>                         | Text      | | | Possible version statuses: `Preview`, `Active`, `Inactive`. When uploading a new version, it should always be in `Preview`. You can then activate or deactivate content via [the API](https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1) or [Management Portal](https://manage.bsdd.buildingsmart.org/). Read more: [the lifecycle of the bSDD content](bSDD%20import%20tutorial.md#the-lifecycle-of-a-dictionary)  |
 | <span id="Classes">Classes</span>          | List of Class    | ✅    | | List of objects of type `Class`. See section [Class](#class)  |
 | <span id="Properties">Properties</span>       | List of Property | ✅    | | List of objects of type `Property`. See section [Property](#property) |
 

--- a/Documentation/bSDD JSON import model.md
+++ b/Documentation/bSDD JSON import model.md
@@ -29,7 +29,7 @@ We also have a demonstration dictionary: ["Fruit and vegetables"](https://search
 
 <h2 id="json-format">JSON format</h2>
 
-You can deliver data for the buildingSMART Data Dictionary in the JSON file following our standard, which we explain in this document. You can also find the JSON and Excel templates in [/Model/Import Model](../Model/Import%20Model/).
+You can deliver data for the buildingSMART Data Dictionary in the JSON file following our standard, which we explain in this document. You can also find the JSON and Excel templates in [/Model/Import Model](<../Model/Import Model/>).
 
 Click on the link to get the list of allowed codes for [countries](https://api.bsdd.buildingsmart.org/api/Country/v1), [languages](https://api.bsdd.buildingsmart.org/api/Language/v1), [units](https://api.bsdd.buildingsmart.org/api/Unit/v1), [reference documents](https://api.bsdd.buildingsmart.org/api/ReferenceDocument/v1) and [ifc class](https://api.bsdd.buildingsmart.org/api/Dictionary/v2/Classes?uri=https%3A%2F%2Fidentifier.buildingsmart.org%2Furi%2Fbuildingsmart%2Fifc%2F4.3).
 If you think there are reference documents missing, please let us know by [posting an issue](https://github.com/buildingSMART/bSDD/issues). All values in JSON must be strings captured in double quotes, including for numeric Example and AllowedValue fields.
@@ -62,7 +62,7 @@ NB Default values will only be applied if a field is not specified. If you speci
 | <span id="QualityAssuranceProcedure">QualityAssuranceProcedure</span>      | Text      | | | Name or short description of the quality assurance procedure used for the dictionary, Example: "ETIM international", "AFNOR NF XP P07-150 (PPBIM)", "bSI process", "UN GHS 2015", "UN CPC 1.1", "Private", "Unknown" |
 | <span id="QualityAssuranceProcedureUrl">QualityAssuranceProcedureUrl</span>   | Text      | | | Url to a web page with more detailed info on the quality assurance procedure, Example: "https://www.buildingsmart.org/about/bsi-process"  |
 | <span id="ReleaseDate">ReleaseDate</span>                    | DateTime  | | | Date of release of the version, See [Date Time format](#datetime-format).  |
-| <span id="Status">Status</span>                         | Text      | | | Possible version statuses: `Preview`, `Active`, `Inactive`. When uploading a new version, it should always be in `Preview`. You can then activate or deactivate content via [the API](https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1) or [Management Portal](https://manage.bsdd.buildingsmart.org/). Read more: [the lifecycle of the bSDD content](bSDD%20import%20tutorial.md#the-lifecycle-of-a-dictionary)  |
+| <span id="Status">Status</span>                         | Text      | | | Possible version statuses: `Preview`, `Active`, `Inactive`. When uploading a new version, it should always be in `Preview`. You can then activate or deactivate content via [the API](https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1) or [Management Portal](https://manage.bsdd.buildingsmart.org/). Read more: [the lifecycle of the bSDD content](<bSDD import tutorial.md#the-lifecycle-of-a-dictionary>)  |
 | <span id="Classes">Classes</span>          | List of Class    | ✅    | | List of objects of type `Class`. See section [Class](#class)  |
 | <span id="Properties">Properties</span>       | List of Property | ✅    | | List of objects of type `Property`. See section [Property](#property) |
 

--- a/Documentation/bSDD and GraphQL.md
+++ b/Documentation/bSDD and GraphQL.md
@@ -32,7 +32,7 @@ Test GraphQL secured endpoint: https://test.bsdd.buildingsmart.org/graphqls/
 
 Production GraphQL secured endpoint: https://api.bsdd.buildingsmart.org/graphqls/
 
-See the [bSDD API documentation](<bSDD API.md>) for information about accessing secured APIs. Accessing the secured GraphQL endpoint works the same way.
+See the [bSDD API documentation](bSDD%20API.md) for information about accessing secured APIs. Accessing the secured GraphQL endpoint works the same way.
 
 ## Example data queries
 

--- a/Documentation/bSDD and GraphQL.md
+++ b/Documentation/bSDD and GraphQL.md
@@ -32,7 +32,7 @@ Test GraphQL secured endpoint: https://test.bsdd.buildingsmart.org/graphqls/
 
 Production GraphQL secured endpoint: https://api.bsdd.buildingsmart.org/graphqls/
 
-See document https://github.com/buildingSMART/bSDD/blob/master/Documentation/bSDD%20API.md for info how to access secured APIs. For accessing the secured GraphQL endpoint it is the same.
+See the [bSDD API documentation](bSDD%20API.md) for information about accessing secured APIs. Accessing the secured GraphQL endpoint works the same way.
 
 ## Example data queries
 

--- a/Documentation/bSDD and GraphQL.md
+++ b/Documentation/bSDD and GraphQL.md
@@ -32,7 +32,7 @@ Test GraphQL secured endpoint: https://test.bsdd.buildingsmart.org/graphqls/
 
 Production GraphQL secured endpoint: https://api.bsdd.buildingsmart.org/graphqls/
 
-See the [bSDD API documentation](bSDD%20API.md) for information about accessing secured APIs. Accessing the secured GraphQL endpoint works the same way.
+See the [bSDD API documentation](<bSDD API.md>) for information about accessing secured APIs. Accessing the secured GraphQL endpoint works the same way.
 
 ## Example data queries
 

--- a/Documentation/bSDD import tutorial.md
+++ b/Documentation/bSDD import tutorial.md
@@ -14,7 +14,7 @@ As part of bSDD housekeeping, we manually review each request, which can take up
 
 The primary form of data upload to bSDD is a properly structured JSON file. In [the data model documentation](https://technical.buildingsmart.org/services/bsdd/data-structure/), we specify what such a file should contain and how to structure it.
 
-You can manually create such a file by coping <a href="../Model/Import Model/bsdd-import-model.json">the JSON template</a>, or use <a href="../Model/Import Model/spreadsheet-import/">the Excel template instructions</a>. Alternatively, use one of <a href="https://technical.buildingsmart.org/resources/software-implementations/?filter_5=bSDD+submit%2Fmanage&amp;mode=any">the third-party tools to manage and upload data dictionaries in bSDD</a>.
+You can manually create such a file by coping <a href="../Model/Import%20Model/bsdd-import-model.json">the JSON template</a>, or use <a href="../Model/Import%20Model/spreadsheet-import/">the Excel template instructions</a>. Alternatively, use one of <a href="https://technical.buildingsmart.org/resources/software-implementations/?filter_5=bSDD+submit%2Fmanage&amp;mode=any">the third-party tools to manage and upload data dictionaries in bSDD</a>.
 
 #### General guidelines
 
@@ -42,7 +42,7 @@ Go to the Dictionaries tab and select your organisation. If you belong to only o
 
 Using the "Select file" button load your dictionary JSON file.
 
-<img src="graphics/bSDD management portal.png" alt="bSDD manage" style="width: 800px" />
+<img src="graphics/bSDD%20management%20portal.png" alt="bSDD manage" style="width: 800px" />
 
 You have the option to first validate if the file is free of errors or upload it for testing by selecting option 'Test upload'. The test upload means the content will be automatically deleted from bSDD after 2 months and it will not be possible to set the status to 'Active' to prevent mistakes.
 

--- a/Documentation/bSDD import tutorial.md
+++ b/Documentation/bSDD import tutorial.md
@@ -14,7 +14,7 @@ As part of bSDD housekeeping, we manually review each request, which can take up
 
 The primary form of data upload to bSDD is a properly structured JSON file. In [the data model documentation](https://technical.buildingsmart.org/services/bsdd/data-structure/), we specify what such a file should contain and how to structure it.
 
-You can manually create such a file by coping <a href="../Model/Import%20Model/bsdd-import-model.json">the JSON template</a>, or use <a href="../Model/Import%20Model/spreadsheet-import/">the Excel template instructions</a>. Alternatively, use one of <a href="https://technical.buildingsmart.org/resources/software-implementations/?filter_5=bSDD+submit%2Fmanage&amp;mode=any">the third-party tools to manage and upload data dictionaries in bSDD</a>.
+You can manually create such a file by coping <a href="../Model/Import Model/bsdd-import-model.json">the JSON template</a>, or use <a href="../Model/Import Model/spreadsheet-import/">the Excel template instructions</a>. Alternatively, use one of <a href="https://technical.buildingsmart.org/resources/software-implementations/?filter_5=bSDD+submit%2Fmanage&amp;mode=any">the third-party tools to manage and upload data dictionaries in bSDD</a>.
 
 #### General guidelines
 
@@ -42,7 +42,7 @@ Go to the Dictionaries tab and select your organisation. If you belong to only o
 
 Using the "Select file" button load your dictionary JSON file.
 
-<img src="graphics/bSDD%20management%20portal.png" alt="bSDD manage" style="width: 800px" />
+<img src="graphics/bSDD management portal.png" alt="bSDD manage" style="width: 800px" />
 
 You have the option to first validate if the file is free of errors or upload it for testing by selecting option 'Test upload'. The test upload means the content will be automatically deleted from bSDD after 2 months and it will not be possible to set the status to 'Active' to prevent mistakes.
 

--- a/Documentation/bSDD import tutorial.md
+++ b/Documentation/bSDD import tutorial.md
@@ -14,7 +14,7 @@ As part of bSDD housekeeping, we manually review each request, which can take up
 
 The primary form of data upload to bSDD is a properly structured JSON file. In [the data model documentation](https://technical.buildingsmart.org/services/bsdd/data-structure/), we specify what such a file should contain and how to structure it.
 
-You can manually create such a file by coping <a href="https://github.com/buildingSMART/bSDD/blob/master/Model/Import%20Model/bsdd-import-model.json">the JSON template</a>, or use <a href="https://github.com/buildingSMART/bSDD/tree/master/Model/Import%20Model/spreadsheet-import">the Excel template instructions</a>. Alternatively, use one of <a href="https://technical.buildingsmart.org/resources/software-implementations/?filter_5=bSDD+submit%2Fmanage&amp;mode=any">the third-party tools to manage and upload data dictionaries in bSDD</a>.
+You can manually create such a file by coping <a href="../Model/Import%20Model/bsdd-import-model.json">the JSON template</a>, or use <a href="../Model/Import%20Model/spreadsheet-import/">the Excel template instructions</a>. Alternatively, use one of <a href="https://technical.buildingsmart.org/resources/software-implementations/?filter_5=bSDD+submit%2Fmanage&amp;mode=any">the third-party tools to manage and upload data dictionaries in bSDD</a>.
 
 #### General guidelines
 
@@ -42,7 +42,7 @@ Go to the Dictionaries tab and select your organisation. If you belong to only o
 
 Using the "Select file" button load your dictionary JSON file.
 
-<img src="https://raw.githubusercontent.com/buildingSMART/bSDD/master/Documentation/graphics/bSDD%20management%20portal.png" alt="bSDD manage" style="width: 800px" />
+<img src="graphics/bSDD%20management%20portal.png" alt="bSDD manage" style="width: 800px" />
 
 You have the option to first validate if the file is free of errors or upload it for testing by selecting option 'Test upload'. The test upload means the content will be automatically deleted from bSDD after 2 months and it will not be possible to set the status to 'Active' to prevent mistakes.
 
@@ -68,7 +68,7 @@ Once the file has been imported, you will receive a more detailed import report 
 
 When you publish a new dictionary version in the bSDD, it always initially has the `Preview` status. At this stage, you can **reupload** the content to modify it, **activate** that version, or permanently **delete** it.
 
-<img src="https://raw.githubusercontent.com/buildingSMART/bSDD/master/Documentation/graphics/Content_lifecycle_workflow.jpg" alt="Lifecycle workflow" />
+<img src="graphics/Content_lifecycle_workflow.jpg" alt="Lifecycle workflow" />
 
 **⚠️ Once the content is activated, it will get an immutable URI, meaning the content will stay in bSDD permanently and can't be deleted.** It is still possible to change the status to `Inactive`, indicating it should no longer be used, but the page will still exist and show the content. Consider that before activating the version of a dictionary.
 

--- a/Documentation/bSDD-IFC documentation.md
+++ b/Documentation/bSDD-IFC documentation.md
@@ -28,7 +28,7 @@ Mapping rules are defined for the following concepts:
 	- [openBIM workflows](#openbim-workflows)
 	- [bSDD - IFC mapping](#bsdd---ifc-mapping)
 		- [1. bSDD dictionary](#1-bsdd-dictionary)
-		- [2. bSDD classes (objects)](#2-bsdd-classes-objects)
+		- [2. bSDD classes (objects)](#2-bsdd-class-objects)
 		- [3. bSDD materials](#3-bsdd-materials)
 		- [4. bSDD properties](#4-bsdd-properties)
 
@@ -234,7 +234,7 @@ _\* IDS references bSDD using URI, instead of copying its content. Thanks to tha
 
 **In bSDD**, a material is defined with a class of type 'Material'. The main difference is in the mapping rules for IFC models. The **bSDD class of type 'Material'** should be linked to the [_IfcMaterial_](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcMaterial.htm), which is then linked to various [_IfcObject_](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcObject.htm).
  
-**In IFC**, [_IfcMaterial_](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcMaterial.htm) are associated with objects through [_IfcRelAssociatesMaterial_](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcRelAssociatesMaterial.htm) relation. However, when more than one material is associated with an element, there are many possible ways to define this relation through layer sets, profiles or constituents (% of content). Read more about: [Material Association](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/content.html), in particular: [Material Constituent Set](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Constituent_Set/content.html), [Material Layer Set Usage](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Constituent_Set/content.html), [Material Profile Set Usage](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Profile_Set_Usage/content.html), [Material Set](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Set/content.html), [Material Single](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Single/content.html).
+**In IFC**, [_IfcMaterial_](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcMaterial.htm) are associated with objects through [_IfcRelAssociatesMaterial_](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcRelAssociatesMaterial.htm) relation. However, when more than one material is associated with an element, there are many possible ways to define this relation through layer sets, profiles or constituents (% of content). Read more about: [Material Association](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/content.html), in particular: [Material Constituent Set](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Constituent_Set/content.html), [Material Layer Set Usage](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Layer_Set_Usage/content.html), [Material Profile Set Usage](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Profile_Set_Usage/content.html), [Material Set](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Set/content.html), [Material Single](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Association/Material_Association/Material_Single/content.html).
 
 Below are the mapping rules for different IFC versions.
 
@@ -248,7 +248,7 @@ _\* IDS references bSDD using URI, instead of copying its content. Thanks to tha
 
 **Snippets**
 
-_For the bSDD snippet, look at the [bSDD classes (objects)](#2.-bSDD-classes-(objects))_
+_For the bSDD snippet, look at the [bSDD classes (objects)](#2-bsdd-class-objects)_
 
 <details><summary>✂️ IFC4x3_ADD2 & IFC4</summary>
 

--- a/Documentation/bSDD-ISO_mapping.md
+++ b/Documentation/bSDD-ISO_mapping.md
@@ -4,9 +4,9 @@
 
 The bSDD is based on ISO12006-3 and ISO23386 standards, which define data dictionaries. For ease of integration with openBIM workflows, the bSDD is stripped down to the essential aspects: defining interrelated terms and properties describing the built environment. The bSDD constraints include the imposed units list, languages list, and types of relations between concepts (ISO leaves freedom of definition to users, hindering interpretation by software). The inheritance structure of ISO12006-3 (Root→Object→Concept→Subject/Property) is simplified in bSDD to one level: Class and Property. 
 
-The ISO allows the versioning of each concept individually, which is important for the development of a data dictionary. In bSDD, to support contractual agreements, each change results in a new version of the complete dictionary. This does not apply if a dictionary is not activated. Read more about [the content lifecycle in bSDD](https://github.com/buildingSMART/bSDD/blob/doc_update/Documentation/bSDD%20import%20tutorial.md).
+The ISO allows the versioning of each concept individually, which is important for the development of a data dictionary. In bSDD, to support contractual agreements, each change results in a new version of the complete dictionary. This does not apply if a dictionary is not activated. Read more about [the content lifecycle in bSDD](bSDD%20import%20tutorial.md#the-lifecycle-of-a-dictionary).
 
-Below is the table mapping the attributes of bSDD and ISO standards. bSDD attributes are defined in [the bSDD data model](https://github.com/buildingSMART/bSDD/blob/doc_update/Documentation/bSDD%20JSON%20import%20model.md). 
+Below is the table mapping the attributes of bSDD and ISO standards. bSDD attributes are defined in [the bSDD data model](bSDD%20JSON%20import%20model.md).
 
 | **bSDD** | **ISO23386:2020** | **ISO12006-3:2022** | **Comment** |
 |---|---|---|---|

--- a/Documentation/bSDD-ISO_mapping.md
+++ b/Documentation/bSDD-ISO_mapping.md
@@ -4,9 +4,9 @@
 
 The bSDD is based on ISO12006-3 and ISO23386 standards, which define data dictionaries. For ease of integration with openBIM workflows, the bSDD is stripped down to the essential aspects: defining interrelated terms and properties describing the built environment. The bSDD constraints include the imposed units list, languages list, and types of relations between concepts (ISO leaves freedom of definition to users, hindering interpretation by software). The inheritance structure of ISO12006-3 (Root→Object→Concept→Subject/Property) is simplified in bSDD to one level: Class and Property. 
 
-The ISO allows the versioning of each concept individually, which is important for the development of a data dictionary. In bSDD, to support contractual agreements, each change results in a new version of the complete dictionary. This does not apply if a dictionary is not activated. Read more about [the content lifecycle in bSDD](bSDD%20import%20tutorial.md#the-lifecycle-of-a-dictionary).
+The ISO allows the versioning of each concept individually, which is important for the development of a data dictionary. In bSDD, to support contractual agreements, each change results in a new version of the complete dictionary. This does not apply if a dictionary is not activated. Read more about [the content lifecycle in bSDD](<bSDD import tutorial.md#the-lifecycle-of-a-dictionary>).
 
-Below is the table mapping the attributes of bSDD and ISO standards. bSDD attributes are defined in [the bSDD data model](bSDD%20JSON%20import%20model.md).
+Below is the table mapping the attributes of bSDD and ISO standards. bSDD attributes are defined in [the bSDD data model](<bSDD JSON import model.md>).
 
 | **bSDD** | **ISO23386:2020** | **ISO12006-3:2022** | **Comment** |
 |---|---|---|---|

--- a/Documentation/bSDD-ISO_mapping.md
+++ b/Documentation/bSDD-ISO_mapping.md
@@ -4,9 +4,9 @@
 
 The bSDD is based on ISO12006-3 and ISO23386 standards, which define data dictionaries. For ease of integration with openBIM workflows, the bSDD is stripped down to the essential aspects: defining interrelated terms and properties describing the built environment. The bSDD constraints include the imposed units list, languages list, and types of relations between concepts (ISO leaves freedom of definition to users, hindering interpretation by software). The inheritance structure of ISO12006-3 (Root→Object→Concept→Subject/Property) is simplified in bSDD to one level: Class and Property. 
 
-The ISO allows the versioning of each concept individually, which is important for the development of a data dictionary. In bSDD, to support contractual agreements, each change results in a new version of the complete dictionary. This does not apply if a dictionary is not activated. Read more about [the content lifecycle in bSDD](<bSDD import tutorial.md#the-lifecycle-of-a-dictionary>).
+The ISO allows the versioning of each concept individually, which is important for the development of a data dictionary. In bSDD, to support contractual agreements, each change results in a new version of the complete dictionary. This does not apply if a dictionary is not activated. Read more about [the content lifecycle in bSDD](bSDD%20import%20tutorial.md#the-lifecycle-of-a-dictionary).
 
-Below is the table mapping the attributes of bSDD and ISO standards. bSDD attributes are defined in [the bSDD data model](<bSDD JSON import model.md>).
+Below is the table mapping the attributes of bSDD and ISO standards. bSDD attributes are defined in [the bSDD data model](bSDD%20JSON%20import%20model.md).
 
 | **bSDD** | **ISO23386:2020** | **ISO12006-3:2022** | **Comment** |
 |---|---|---|---|

--- a/Meetings/2021 Content workshop/readme.md
+++ b/Meetings/2021 Content workshop/readme.md
@@ -8,11 +8,11 @@
 - Wolfgang Wikes- Semaino
 
 ## Agenda
-- bSDD overview and bSDD standards compliance : [see](https://github.com/buildingSMART/bSDD/blob/master/2021%20Content%20workshop/210519%20FGR%20bSDD%20Workshop%20final.pdf)
-- CCI content import story (Søren Spile) : [see](https://github.com/buildingSMART/bSDD/blob/master/2021%20Content%20workshop/CCI_bSDD%20experiences_20210519.pdf)
-- Mapping dictionary data to bSDD (Wolgang Wilkes) : [see](https://github.com/buildingSMART/bSDD/blob/master/2021%20Content%20workshop/bSDD%20Workshop%20presentation%20Wolfgang%20Wilkes.pdf)
+- bSDD overview and bSDD standards compliance : [see](210519%20FGR%20bSDD%20Workshop%20final.pdf)
+- CCI content import story (Søren Spile) : [see](CCI_bSDD%20experiences_20210519.pdf)
+- Mapping dictionary data to bSDD (Wolgang Wilkes) : [see](bSDD%20Workshop%20presentation%20Wolfgang%20Wilkes.pdf)
 - Pushing content into bSDD (Erik Baars)
-- Interactive Walkthrough of the bSDD import model  : [see](https://github.com/buildingSMART/bSDD/blob/master/2020%20prototype/import-model/bSDD%20JSON%20import%20model.md)
+- Interactive Walkthrough of the bSDD import model  : [see](../../Documentation/bSDD%20JSON%20import%20model.md)
 
 ## Recording
 [see on Vimeo](https://vimeo.com/553234172/e024861065)

--- a/Meetings/2021 Content workshop/readme.md
+++ b/Meetings/2021 Content workshop/readme.md
@@ -8,11 +8,11 @@
 - Wolfgang Wikes- Semaino
 
 ## Agenda
-- bSDD overview and bSDD standards compliance : [see](<210519 FGR bSDD Workshop final.pdf>)
-- CCI content import story (Søren Spile) : [see](<CCI_bSDD experiences_20210519.pdf>)
-- Mapping dictionary data to bSDD (Wolgang Wilkes) : [see](<bSDD Workshop presentation Wolfgang Wilkes.pdf>)
+- bSDD overview and bSDD standards compliance : [see](210519%20FGR%20bSDD%20Workshop%20final.pdf)
+- CCI content import story (Søren Spile) : [see](CCI_bSDD%20experiences_20210519.pdf)
+- Mapping dictionary data to bSDD (Wolgang Wilkes) : [see](bSDD%20Workshop%20presentation%20Wolfgang%20Wilkes.pdf)
 - Pushing content into bSDD (Erik Baars)
-- Interactive Walkthrough of the bSDD import model  : [see](<../../Documentation/bSDD JSON import model.md>)
+- Interactive Walkthrough of the bSDD import model  : [see](../../Documentation/bSDD%20JSON%20import%20model.md)
 
 ## Recording
 [see on Vimeo](https://vimeo.com/553234172/e024861065)

--- a/Meetings/2021 Content workshop/readme.md
+++ b/Meetings/2021 Content workshop/readme.md
@@ -8,11 +8,11 @@
 - Wolfgang Wikes- Semaino
 
 ## Agenda
-- bSDD overview and bSDD standards compliance : [see](210519%20FGR%20bSDD%20Workshop%20final.pdf)
-- CCI content import story (Søren Spile) : [see](CCI_bSDD%20experiences_20210519.pdf)
-- Mapping dictionary data to bSDD (Wolgang Wilkes) : [see](bSDD%20Workshop%20presentation%20Wolfgang%20Wilkes.pdf)
+- bSDD overview and bSDD standards compliance : [see](<210519 FGR bSDD Workshop final.pdf>)
+- CCI content import story (Søren Spile) : [see](<CCI_bSDD experiences_20210519.pdf>)
+- Mapping dictionary data to bSDD (Wolgang Wilkes) : [see](<bSDD Workshop presentation Wolfgang Wilkes.pdf>)
 - Pushing content into bSDD (Erik Baars)
-- Interactive Walkthrough of the bSDD import model  : [see](../../Documentation/bSDD%20JSON%20import%20model.md)
+- Interactive Walkthrough of the bSDD import model  : [see](<../../Documentation/bSDD JSON import model.md>)
 
 ## Recording
 [see on Vimeo](https://vimeo.com/553234172/e024861065)

--- a/Meetings/2021 Hackathon/tutorial.md
+++ b/Meetings/2021 Hackathon/tutorial.md
@@ -4,7 +4,7 @@ IMPORTANT: naming and (some) example API calls in this file are outdated! Please
 
 How to use the buildingSMART Data Dictionary API?
 
-You can find a lot of info regarding the bSDD API on https://github.com/buildingSMART/bSDD/tree/master/2020%20prototype.
+You can find information about the bSDD API in the [bSDD API documentation](../../Documentation/bSDD%20API.md).
 But where to start using the API?
 
 ## Context
@@ -31,8 +31,8 @@ For this tutorial there is no need to sign up.
 
 Some resources for you to get to know more about bSDD and using the API:
 
-Main resource location of the bSDD API: https://github.com/buildingSMART/bSDD/tree/master/2020%20prototype.
-Authenticated call to the bSDD API from a .NET Console App: https://github.com/buildingSMART/bSDD/tree/master/2020%20prototype/CSharp-Client-Console-Demo
+Main resource location of the bSDD API: [bSDD API documentation](../../Documentation/bSDD%20API.md).
+Authenticated call to the bSDD API from a .NET Console App: [.NET console example](../../Source%20code%20examples/CSharp-Client-Console-Demo/)
 Azure AD B2C documentation home page: http://aka.ms/aadb2c
 More Azure AD B2C code samples: https://docs.microsoft.com/en-us/azure/active-directory-b2c/code-samples
 The API swagger page: https://test.bsdd.buildingsmart.org/swagger
@@ -48,7 +48,7 @@ Most bSDD API calls do not require any form of authentication yet, so for this t
 ## Part 1 - get a list of the domains
 
 Prepare your app for doing a HTTP request to the buildingSMART Data Dictionary API.
-How to do this depends a lot on the language you use for building your app. If you're using .NET and C#, have a look at the demo console app: https://github.com/buildingSMART/bSDD/tree/master/2020%20prototype/CSharp-Client-Console-Demo
+How to do this depends a lot on the language you use for building your app. If you're using .NET and C#, have a look at the [.NET console example](../../Source%20code%20examples/CSharp-Client-Console-Demo/).
 
 Call the Domain API to get a list of all domains.
 API url: https://test.bsdd.buildingsmart.org/api/Domain/v2

--- a/Meetings/2021 Hackathon/tutorial.md
+++ b/Meetings/2021 Hackathon/tutorial.md
@@ -4,7 +4,7 @@ IMPORTANT: naming and (some) example API calls in this file are outdated! Please
 
 How to use the buildingSMART Data Dictionary API?
 
-You can find information about the bSDD API in the [bSDD API documentation](../../Documentation/bSDD%20API.md).
+You can find information about the bSDD API in the [bSDD API documentation](<../../Documentation/bSDD API.md>).
 But where to start using the API?
 
 ## Context
@@ -31,8 +31,8 @@ For this tutorial there is no need to sign up.
 
 Some resources for you to get to know more about bSDD and using the API:
 
-Main resource location of the bSDD API: [bSDD API documentation](../../Documentation/bSDD%20API.md).
-Authenticated call to the bSDD API from a .NET Console App: [.NET console example](../../Source%20code%20examples/CSharp-Client-Console-Demo/)
+Main resource location of the bSDD API: [bSDD API documentation](<../../Documentation/bSDD API.md>).
+Authenticated call to the bSDD API from a .NET Console App: [.NET console example](<../../Source code examples/CSharp-Client-Console-Demo/>).
 Azure AD B2C documentation home page: http://aka.ms/aadb2c
 More Azure AD B2C code samples: https://docs.microsoft.com/en-us/azure/active-directory-b2c/code-samples
 The API swagger page: https://test.bsdd.buildingsmart.org/swagger
@@ -48,7 +48,7 @@ Most bSDD API calls do not require any form of authentication yet, so for this t
 ## Part 1 - get a list of the domains
 
 Prepare your app for doing a HTTP request to the buildingSMART Data Dictionary API.
-How to do this depends a lot on the language you use for building your app. If you're using .NET and C#, have a look at the [.NET console example](../../Source%20code%20examples/CSharp-Client-Console-Demo/).
+How to do this depends a lot on the language you use for building your app. If you're using .NET and C#, have a look at the [.NET console example](<../../Source code examples/CSharp-Client-Console-Demo/>).
 
 Call the Domain API to get a list of all domains.
 API url: https://test.bsdd.buildingsmart.org/api/Domain/v2

--- a/Meetings/2021 Hackathon/tutorial.md
+++ b/Meetings/2021 Hackathon/tutorial.md
@@ -4,7 +4,7 @@ IMPORTANT: naming and (some) example API calls in this file are outdated! Please
 
 How to use the buildingSMART Data Dictionary API?
 
-You can find information about the bSDD API in the [bSDD API documentation](<../../Documentation/bSDD API.md>).
+You can find information about the bSDD API in the [bSDD API documentation](../../Documentation/bSDD%20API.md).
 But where to start using the API?
 
 ## Context
@@ -31,8 +31,8 @@ For this tutorial there is no need to sign up.
 
 Some resources for you to get to know more about bSDD and using the API:
 
-Main resource location of the bSDD API: [bSDD API documentation](<../../Documentation/bSDD API.md>).
-Authenticated call to the bSDD API from a .NET Console App: [.NET console example](<../../Source code examples/CSharp-Client-Console-Demo/>).
+Main resource location of the bSDD API: [bSDD API documentation](../../Documentation/bSDD%20API.md).
+Authenticated call to the bSDD API from a .NET Console App: [.NET console example](../../Source%20code%20examples/CSharp-Client-Console-Demo/)
 Azure AD B2C documentation home page: http://aka.ms/aadb2c
 More Azure AD B2C code samples: https://docs.microsoft.com/en-us/azure/active-directory-b2c/code-samples
 The API swagger page: https://test.bsdd.buildingsmart.org/swagger
@@ -48,7 +48,7 @@ Most bSDD API calls do not require any form of authentication yet, so for this t
 ## Part 1 - get a list of the domains
 
 Prepare your app for doing a HTTP request to the buildingSMART Data Dictionary API.
-How to do this depends a lot on the language you use for building your app. If you're using .NET and C#, have a look at the [.NET console example](<../../Source code examples/CSharp-Client-Console-Demo/>).
+How to do this depends a lot on the language you use for building your app. If you're using .NET and C#, have a look at the [.NET console example](../../Source%20code%20examples/CSharp-Client-Console-Demo/).
 
 Call the Domain API to get a list of all domains.
 API url: https://test.bsdd.buildingsmart.org/api/Domain/v2

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ At the heart of bSDD is a canonical database, where all dictionaries can be rela
 ### Quick links
 
 * [bSDD project page](https://www.buildingsmart.org/users/services/buildingsmart-data-dictionary/)
-* [bSDD Search page]()
-* [bSDD Manage portal]()
+* [bSDD Search page](https://search.bsdd.buildingsmart.org/)
+* [bSDD Manage portal](https://manage.bsdd.buildingsmart.org/)
 * [bSDD API Swagger page]()
-* [bSDD updates forum]()
+* [bSDD updates forum](https://forums.buildingsmart.org/t/bsdd-tech-updates/4889)
 * [bSDD data structure](/Documentation/bSDD%20JSON%20import%20model.md)
 * [bSDD JSON template](/Model/Import%20Model/bsdd-import-model.json) / [bSDD Excel template](/Model/Import%20Model/spreadsheet-import)
 * [Tools integrating bSDD](https://technical.buildingsmart.org/resources/software-implementations/?filter_5%5B%5D=bSDD%20read%20API&filter_5%5B%5D=bSDD%20submit%2Fmanage&filter_5%5B%5D=bSDD%20IFC%20export%20(including%20URIs)&filter_1=&gv_search=&mode=any). This is a self-managed list, so feel free to add missing ones.
@@ -33,7 +33,7 @@ At the heart of bSDD is a canonical database, where all dictionaries can be rela
 📢 We inform about planned and recently implemented bSDD updates in this forum topic:
 [bSDD Tech Updates](https://forums.buildingsmart.org/t/bsdd-tech-updates/4889).
 
-* **API documentation** https://github.com/buildingSMART/bSDD/blob/master/Documentation/bSDD%20API.md
+* **API documentation** [bSDD API](Documentation/bSDD%20API.md)
 * **API interactive documentation** on Swagger: https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1
 
 We also provide a **TEST** environment where the latest features are rolled out first and tested. If you want to check it out, here are the equivalent pages (not to be used by end-users!):

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At the heart of bSDD is a canonical database, where all dictionaries can be rela
 📢 We inform about planned and recently implemented bSDD updates in this forum topic:
 [bSDD Tech Updates](https://forums.buildingsmart.org/t/bsdd-tech-updates/4889).
 
-* **API documentation** [bSDD API](Documentation/bSDD%20API.md)
+* **API documentation** [bSDD API](<Documentation/bSDD API.md>)
 * **API interactive documentation** on Swagger: https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1
 
 We also provide a **TEST** environment where the latest features are rolled out first and tested. If you want to check it out, here are the equivalent pages (not to be used by end-users!):

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At the heart of bSDD is a canonical database, where all dictionaries can be rela
 📢 We inform about planned and recently implemented bSDD updates in this forum topic:
 [bSDD Tech Updates](https://forums.buildingsmart.org/t/bsdd-tech-updates/4889).
 
-* **API documentation** [bSDD API](<Documentation/bSDD API.md>)
+* **API documentation** [bSDD API](Documentation/bSDD%20API.md)
 * **API interactive documentation** on Swagger: https://app.swaggerhub.com/apis/buildingSMART/Dictionaries/v1
 
 We also provide a **TEST** environment where the latest features are rolled out first and tested. If you want to check it out, here are the equivalent pages (not to be used by end-users!):

--- a/Source code examples/Python-Client-Console-Demo/Readme.md
+++ b/Source code examples/Python-Client-Console-Demo/Readme.md
@@ -4,7 +4,7 @@ IMPORTANT: naming and (some) example API calls in this file are outdated! Please
 
 The Python console app provides the API calls needed to implement the use case presented in the Hackathon on 2021 3th of March.
 
-see: https://github.com/buildingSMART/bSDD/blob/master/2021%20Hackathon/tutorial.md
+See the [March 2021 Hackathon tutorial](../../Meetings/2021%20Hackathon/tutorial.md).
 
 1- Get the list of available domains in bSDD
 

--- a/Source code examples/Python-Client-Console-Demo/Readme.md
+++ b/Source code examples/Python-Client-Console-Demo/Readme.md
@@ -4,7 +4,7 @@ IMPORTANT: naming and (some) example API calls in this file are outdated! Please
 
 The Python console app provides the API calls needed to implement the use case presented in the Hackathon on 2021 3th of March.
 
-See the [March 2021 Hackathon tutorial](../../Meetings/2021%20Hackathon/tutorial.md).
+See the [March 2021 Hackathon tutorial](<../../Meetings/2021 Hackathon/tutorial.md>).
 
 1- Get the list of available domains in bSDD
 

--- a/Source code examples/Python-Client-Console-Demo/Readme.md
+++ b/Source code examples/Python-Client-Console-Demo/Readme.md
@@ -4,7 +4,7 @@ IMPORTANT: naming and (some) example API calls in this file are outdated! Please
 
 The Python console app provides the API calls needed to implement the use case presented in the Hackathon on 2021 3th of March.
 
-See the [March 2021 Hackathon tutorial](<../../Meetings/2021 Hackathon/tutorial.md>).
+See the [March 2021 Hackathon tutorial](../../Meetings/2021%20Hackathon/tutorial.md).
 
 1- Get the list of available domains in bSDD
 


### PR DESCRIPTION
## Summary
- Replace outdated GitHub, website, and documentation URLs
- Correct broken relative links and anchors across documentation and meeting materials
- Add valid bSDD Search and Manage portal links to the README
- Update image references to use local repository assets

## Testing
- Not run (not requested)